### PR TITLE
feat : 이메일 api 구현 및 6자리 인증코드 발송,  아이디 및 비밀번호 찾기 1차 mapper, service, controller(백엔드) 1차 구현.

### DIFF
--- a/ifive/build.gradle
+++ b/ifive/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
 	// testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/ifive/src/main/java/kr/co/milionvolt/ifive/controller/EmailController.java
+++ b/ifive/src/main/java/kr/co/milionvolt/ifive/controller/EmailController.java
@@ -1,0 +1,28 @@
+package kr.co.milionvolt.ifive.controller;
+
+import kr.co.milionvolt.ifive.service.EmailService;
+import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+public class EmailController {
+    @Autowired
+    private EmailService emailService;
+
+    @GetMapping("/email/{email}")
+    public ResponseEntity<Integer> display(@PathVariable String email){
+        System.out.println(email);
+        int num = emailService.setMailSend(email);
+
+        ResponseEntity entity= new ResponseEntity(num, HttpStatus.OK);
+        return entity;
+    }
+
+}

--- a/ifive/src/main/java/kr/co/milionvolt/ifive/controller/UserController.java
+++ b/ifive/src/main/java/kr/co/milionvolt/ifive/controller/UserController.java
@@ -1,0 +1,49 @@
+package kr.co.milionvolt.ifive.controller;
+
+import kr.co.milionvolt.ifive.model.UserVO;
+import kr.co.milionvolt.ifive.service.UserService;
+import org.apache.catalina.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/user")
+public class UserController {
+    @Autowired
+    private UserService userService;
+
+    @GetMapping("/findId/{username}/{email}")
+    public ResponseEntity<UserVO> findById(@PathVariable String username,
+                                           @PathVariable String email){
+       UserVO vo =  userService.findByID(username,email);
+       ResponseEntity<UserVO> entity = new ResponseEntity<>(vo, HttpStatus.OK);
+       return entity;
+    }
+
+    @GetMapping("/findPwd/{userId}") // 비밀번호 1페이지 기능 구현
+    public ResponseEntity<String> findPwdByUserId(@PathVariable String userId){
+        String email = userService.findPasswordByUserId(userId);
+        ResponseEntity<String> entity = new ResponseEntity<>(email,HttpStatus.OK);
+        return entity; // 이메일 반환.  -> vue에서 정규화 표현으로 어느정도 가리고 보여주고
+        // 입력한 이메일이랑 맞는지 비교.
+    }
+
+    @GetMapping("/findPwd2/{username}/{email}")
+    public ResponseEntity<UserVO> findPwd(@PathVariable String username,
+                                          @PathVariable String email){
+        UserVO vo =userService.findPass(username, email);
+        ResponseEntity<UserVO> entity = new ResponseEntity<>(vo, HttpStatus.OK);
+        return entity;
+    }
+
+    @PutMapping("/newPwd")
+    @Transactional
+    public ResponseEntity<String> newPwd(@RequestBody UserVO vo){
+        userService.newPwd(vo);
+        ResponseEntity<String> entity = new ResponseEntity<>("비밀번호 수정 완료",HttpStatus.OK);
+        return entity;
+    }
+}

--- a/ifive/src/main/java/kr/co/milionvolt/ifive/mapper/UserMapper.java
+++ b/ifive/src/main/java/kr/co/milionvolt/ifive/mapper/UserMapper.java
@@ -1,0 +1,34 @@
+package kr.co.milionvolt.ifive.mapper;
+
+import kr.co.milionvolt.ifive.model.UserVO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+@Mapper
+public interface UserMapper {
+
+    @Select(" SELECT user_id, created_at FROM user " +
+            " WHERE username = #{username} " +
+            " AND email = #{email} ")
+    public UserVO findById(String username, String email);
+
+    @Select(" SELECT email FROM user " +
+            " WHERE user_id = #{userId}")
+    public String findPasswordByUserId(String userId);
+
+    @Select(" SELECT username, user_id, email, password " +
+            " FROM user " +
+            " WHERE username = #{username} " +
+            " AND email = #{email} ")
+    public UserVO findPassword(String username , String email);
+
+    @Update(" UPDATE user SET password = #{password}" +
+            " WHERE user_id = #{user_id} " +
+            " AND username = #{username} " +
+            " AND email = #{email} ")
+    public void newPassword(UserVO vo);
+
+}
+
+

--- a/ifive/src/main/java/kr/co/milionvolt/ifive/model/UserVO.java
+++ b/ifive/src/main/java/kr/co/milionvolt/ifive/model/UserVO.java
@@ -1,0 +1,21 @@
+package kr.co.milionvolt.ifive.model;
+
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class UserVO {
+    private int id;
+    private String username;
+    private String user_id;
+    private String email;
+    private String phone_number;
+    private String password;
+    private String level_id;
+    private Timestamp created_at;
+}

--- a/ifive/src/main/java/kr/co/milionvolt/ifive/service/EmailService.java
+++ b/ifive/src/main/java/kr/co/milionvolt/ifive/service/EmailService.java
@@ -1,0 +1,31 @@
+package kr.co.milionvolt.ifive.service;
+
+import lombok.AllArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Service
+@AllArgsConstructor
+public class EmailService {
+    private JavaMailSender mailSender;
+    private static final String FROM_ADDRESS = "gjsdms1244@gmail.com";
+
+    public int setMailSend(String email){
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email); // 받는 메일
+        message.setFrom(EmailService.FROM_ADDRESS); //보내는 이메일
+        message.setSubject("백만볼트 인증번호"); // 제목
+
+        Random random = new Random();
+        int sixDigitNumber = 100000 + random.nextInt(900000);
+        String strNumber = String.valueOf(sixDigitNumber);
+
+        message.setText("백만볼트 이메일 인증번호 6자리 : "+strNumber); // 내용.
+        mailSender.send(message);
+
+        return sixDigitNumber;
+    }
+}

--- a/ifive/src/main/java/kr/co/milionvolt/ifive/service/UserService.java
+++ b/ifive/src/main/java/kr/co/milionvolt/ifive/service/UserService.java
@@ -1,0 +1,10 @@
+package kr.co.milionvolt.ifive.service;
+
+import kr.co.milionvolt.ifive.model.UserVO;
+
+public interface UserService {
+    public UserVO findByID(String username, String email);
+    public String findPasswordByUserId(String userId);
+    public UserVO findPass(String username, String email);
+    public void newPwd(UserVO vo);
+}

--- a/ifive/src/main/java/kr/co/milionvolt/ifive/service/UserServiceImpl.java
+++ b/ifive/src/main/java/kr/co/milionvolt/ifive/service/UserServiceImpl.java
@@ -1,0 +1,40 @@
+package kr.co.milionvolt.ifive.service;
+
+import kr.co.milionvolt.ifive.mapper.UserMapper;
+import kr.co.milionvolt.ifive.model.UserVO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+
+@Service
+public class UserServiceImpl implements UserService {
+    @Autowired
+    private UserMapper userMapper;
+    // private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    // 시큐리티 적용 시 사용.
+
+
+    @Override
+    public UserVO findByID(String username, String email) {
+       UserVO vo = userMapper.findById(username, email);
+       return vo;
+    }
+
+    @Override
+    public String findPasswordByUserId(String userId) {
+        String  email = userMapper.findPasswordByUserId(userId);
+        return email;
+    }
+
+    @Override
+    public UserVO findPass(String username, String email) {
+       UserVO vo =  userMapper.findPassword(username,email);
+        return vo;
+    }
+
+    @Override
+    public void newPwd(UserVO vo) {
+        // vo.setPassword(bCryptPasswordEncoder.encode(vo.getPassword()));
+        userMapper.newPassword(vo);
+    }
+}

--- a/ifive/src/main/resources/application.properties
+++ b/ifive/src/main/resources/application.properties
@@ -10,3 +10,10 @@ spring.datasource.driver-class-name: com.mysql.cj.jdbc.Driver
 logging.level.org.springframework.web=info
 logging.level.com.example.springedu=debug
 logging.level.thymeleaf.exam=trace
+
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=gjsdms1244@gmail.com
+spring.mail.password=colx ysbx sael fxec
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/ifive/src/test/java/kr/co/milionvolt/ifive/mapper/UserMapperJunitTest.java
+++ b/ifive/src/test/java/kr/co/milionvolt/ifive/mapper/UserMapperJunitTest.java
@@ -1,0 +1,51 @@
+package kr.co.milionvolt.ifive.mapper;
+
+import kr.co.milionvolt.ifive.model.UserVO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class UserMapperJunitTest {
+    @Autowired
+    private UserMapper userMapper;
+
+    @Test
+    public void findById(){ // 아이디 찾기 기능 Test
+       UserVO vo =  userMapper.findById("강재헌","wogjsdl1244@naver.com");
+        System.out.println(vo);
+       System.out.println(vo.getUser_id());
+        System.out.println(vo.getCreated_at());
+    }
+
+    @Test
+    public void findPasswordByUserId(){ // 비밀번호 찾기 전 해당하는 아이디가 존재하는지 확인.
+        String email = userMapper.findPasswordByUserId("wogjsdl1244");
+        System.out.println(email);
+    }
+
+    @Test
+    public void findPwd(){
+        String username = "강재헌";
+        String email = "wogjsdl1244@naver.com";
+        UserVO vo = userMapper.findPassword(username,email);
+
+        System.out.println(vo);
+
+    }
+
+    @Test
+    public void newPassword(){
+        UserVO vo = new UserVO();
+        vo.setPassword("1111");
+        vo.setUser_id("wogjsdl1244");
+        vo.setUsername("강재헌");
+        vo.setEmail("wogjsdl1244@naver.com");
+
+        userMapper.newPassword(vo);
+
+
+
+    }
+}
+

--- a/ifive/src/test/java/kr/co/milionvolt/ifive/service/UserServiceJunitTest.java
+++ b/ifive/src/test/java/kr/co/milionvolt/ifive/service/UserServiceJunitTest.java
@@ -1,0 +1,41 @@
+package kr.co.milionvolt.ifive.service;
+
+import kr.co.milionvolt.ifive.model.UserVO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+public class UserServiceJunitTest {
+    @Autowired
+    private UserService userService;
+
+    @Test
+    public void findbyId(){
+        String username ="강재헌";
+        String email = "wogjsdl1244@naver.com";
+        UserVO vo = userService.findByID(username,email);
+        System.out.println(vo);
+    }
+
+    @Test
+    public void findPasswordByUserId(){
+        String userId = "wogjsdl1244";
+        String userId2 = "wogjsdl1234";
+        String email = userService.findPasswordByUserId(userId);
+        System.out.println(email);
+    }
+
+    @Test
+    public void findPwd(){
+        UserVO vo = new UserVO();
+        vo.setPassword("1244");
+        vo.setUser_id("wogjsdl1244");
+        vo.setUsername("강재헌");
+        vo.setEmail("wogjsdl1244@naver.com");
+
+        userService.newPwd(vo);
+
+    }
+}


### PR DESCRIPTION
이메일 api 구현
implementation 'org.springframework.boot:spring-boot-starter-mail'  build.gradle에 추가

밑 url로 요청 시 밑 컨트롤러로 이동. ( 반환값은 랜덤번호이며 이를 통해 view에서 비교해줄 예정. )
![image](https://github.com/user-attachments/assets/7f4bbb0a-52e4-4071-a95a-a7473bcef72d)

setMailsend 메서드 실행 시 @Pathvariable로 들어온 이메일 주소를 받아서 랜덤 객체를 이용해서 랜덤번호 6자리 생성 후 발송
![image](https://github.com/user-attachments/assets/37c1a17e-d6f0-4088-b788-9d1e9d1f668c)

아직은 허접하지만 이메일이 오는 것을 확인 할 수 있음. 
![image](https://github.com/user-attachments/assets/9f00c088-80cd-4faf-85e6-dab6f95cf565)

아이디 찾기와 비밀번호 찾기의 매퍼단 구현. 
![image](https://github.com/user-attachments/assets/5512a526-77eb-45d6-85c7-e01166823c01)
2번째 쿼리에서 email만 반환하는 것을 볼 수 있는데 이는 밑의 사진처럼 이메일로 정규화 표현을 해서 보여줄 예정이다.(UI수정)
![image.png](https://prod-files-secure.s3.us-west-2.amazonaws.com/8cae40d9-8dce-4a73-88f4-30b1c5214759/3cd2f5c6-8fa1-4ef5-9a4f-06e923d604e6/image.png)

서비스단 구현. (예외처리 적용은 아직 안했음.)
![image](https://github.com/user-attachments/assets/faee5e49-99b7-4948-9f88-a5c661a3797e)

컨트롤러단 구현
![image](https://github.com/user-attachments/assets/eba7ad2d-9ae7-48cc-a5de-13e984fd02d3)

Test 구현 
MapperTest
![image](https://github.com/user-attachments/assets/8c2473b7-0cad-4b66-9c47-6bfeef0da8ee)

ServiceTest
![image](https://github.com/user-attachments/assets/61e8e6ba-b5d8-4a80-b857-d2dc1dc38919)


컨트롤러 테스는 Talend API Tester로 테스트 했다.
![image](https://github.com/user-attachments/assets/36526a44-7d84-4d42-9b25-9c5ae108de13)






